### PR TITLE
Fix encode timer statistics update

### DIFF
--- a/src/sender_receiver.cpp
+++ b/src/sender_receiver.cpp
@@ -70,7 +70,7 @@ void run_sender(const string& target_ip, const vector<int>& target_ports) {
             vector<uint8_t> encoded;
             encoder.encodeFrame(frame, encoded);
             auto te1 = Clock::now();
-            stats[ENCODE] + chrono::duration<double, milli>(te1 - te0).count();
+            stats[ENCODE] += chrono::duration<double, milli>(te1 - te0).count();
 
             auto ts0 = Clock::now();
             auto chunks = slice_frame(encoded, frame_id, 1000);
@@ -194,4 +194,3 @@ void run_receiver(const vector<int>& ports) {
     for (int sock : sockets) close(sock);
     destroyAllWindows();
 }
-=


### PR DESCRIPTION
## Summary
- fix encoding time accumulation in stats
- remove stray '=' at end of `run_receiver`
- confirm `sender_receiver.cpp` compiles

## Testing
- `g++ -std=c++17 -Iinclude $(pkg-config --cflags opencv4) -c src/sender_receiver.cpp -o /tmp/sender_receiver.o && echo "compiled"`

------
https://chatgpt.com/codex/tasks/task_e_688cdecf189c832cacdc522cc7ce8519