### PR TITLE
Fix chunk size deduction and missing includes

### DIFF
--- a/include/erasure_coder.hpp
+++ b/include/erasure_coder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cstdint>
 
 class ErasureCoder {
 public:

--- a/src/erasure_coder.cpp
+++ b/src/erasure_coder.cpp
@@ -1,6 +1,7 @@
 #include "erasure_coder.hpp"
 #include <algorithm>
 #include <stdexcept>
+#include <cstdint>
 
 ErasureCoder::ErasureCoder(int k, int r, int w)
     : k_(k), r_(r), w_(w), bitmatrix_(nullptr) {}

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -12,7 +12,7 @@ std::vector<Chunk> slice_frame(const std::vector<uint8_t>& frame_data,
 
     for (size_t i = 0; i < total_chunks; ++i) {
         size_t offset = i * chunk_size;
-        size_t len = std::min(chunk_size, frame_data.size() - offset);
+        size_t len = std::min(static_cast<size_t>(chunk_size), frame_data.size() - offset);
 
         Chunk c;
         c.frame_id = frame_id;


### PR DESCRIPTION
## Summary
- fix type mismatch in `slice_frame`
- add `<cstdint>` includes for `ErasureCoder`

## Testing
- `g++ -std=c++17 -c src/slicer.cpp -I include -o /tmp/slicer.o`

------
https://chatgpt.com/codex/tasks/task_e_688cdecdb460832cafbc0c3083cc53b2