### PR TITLE
Handle small frames in FEC encoding

### DIFF
--- a/include/ffmpeg_encoder.h
+++ b/include/ffmpeg_encoder.h
@@ -22,7 +22,7 @@ private:
     int m_width, m_height, m_fps, m_bitrate;
     int frameCounter = 0;
 
-    AVCodec* codec = nullptr;
+    const AVCodec* codec = nullptr;
     AVCodecContext* codecContext = nullptr;
     AVFrame* frame = nullptr;
     AVPacket* pkt = nullptr;

--- a/src/sender_receiver.cpp
+++ b/src/sender_receiver.cpp
@@ -79,6 +79,11 @@ void run_sender(const string& target_ip, const vector<int>& target_ports) {
             for (int i = 0; i < 8 && i < chunks.size(); ++i)
                 k_blocks.push_back(chunks[i].payload);
 
+            if (k_blocks.size() < 8) {
+                size_t block_size = k_blocks.empty() ? 0 : k_blocks[0].size();
+                k_blocks.resize(8, vector<uint8_t>(block_size, 0));
+            }
+
             vector<vector<uint8_t>> all_blocks;
             fec.encode(k_blocks, all_blocks);
 


### PR DESCRIPTION
## Summary
- pad missing data chunks before FEC encoding so small frames don't trigger runtime error
- update FFmpeg encoder to use a `const AVCodec*`

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_688cf59fad70832cad94cf8c81bbe168