### PR TITLE
Add adaptive bitrate and real RS FEC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Include paths
 include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(/usr/include/jerasure)
 
 # Source files
 file(GLOB_RECURSE SOURCES
@@ -29,11 +30,13 @@ target_link_libraries(novaengine ${OpenCV_LIBS})
 find_library(AVCODEC_LIB avcodec)
 find_library(AVUTIL_LIB avutil)
 find_library(SWSCALE_LIB swscale)
+find_library(JERASURE_LIB Jerasure)
+find_library(GFCOMPLETE_LIB gf_complete)
 
-if(AVCODEC_LIB AND AVUTIL_LIB AND SWSCALE_LIB)
-    target_link_libraries(novaengine ${AVCODEC_LIB} ${AVUTIL_LIB} ${SWSCALE_LIB})
+if(AVCODEC_LIB AND AVUTIL_LIB AND SWSCALE_LIB AND JERASURE_LIB AND GFCOMPLETE_LIB)
+    target_link_libraries(novaengine ${AVCODEC_LIB} ${AVUTIL_LIB} ${SWSCALE_LIB} ${JERASURE_LIB} ${GFCOMPLETE_LIB})
 else()
-    message(FATAL_ERROR "FFmpeg libraries not found")
+    message(FATAL_ERROR "FFmpeg or Jerasure libraries not found")
 endif()
 
 # Linux sistem linkleri

--- a/include/erasure_coder.hpp
+++ b/include/erasure_coder.hpp
@@ -5,12 +5,16 @@
 class ErasureCoder {
 public:
     ErasureCoder(int k, int r, int w = 8);
+    ~ErasureCoder();
+
     void encode(const std::vector<std::vector<uint8_t>>& k_chunks,
                 std::vector<std::vector<uint8_t>>& out_blocks); // size = k+r
-    bool decode(const std::vector<std::vector<uint8_t>>& recv_chunks,
+
+    bool decode(const std::vector<std::vector<uint8_t>>& blocks,
+                const std::vector<bool>& received,
                 std::vector<uint8_t>& recovered_data);
 private:
     int k_, r_, w_;
-    int* bitmatrix_;
+    int* matrix_;
 };
 

--- a/include/ffmpeg_encoder.h
+++ b/include/ffmpeg_encoder.h
@@ -18,6 +18,10 @@ public:
     // BGR Mat -> H264 encode edilmiş veri
     bool encodeFrame(const cv::Mat& bgrFrame, std::vector<uint8_t>& outEncodedData);
 
+    // Dinamik bitrate ayarı (kbps)
+    void setBitrate(int bitrate);
+    int getBitrate() const { return m_bitrate; }
+
 private:
     int m_width, m_height, m_fps, m_bitrate;
     int frameCounter = 0;

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -18,6 +18,7 @@ class WeightedScheduler {
 public:
     explicit WeightedScheduler(const std::vector<PathStats>& paths);
     PathStats select_path();
+    void update_metrics(const std::vector<PathStats>& paths);
 
 private:
     std::vector<PathStats> paths_;

--- a/include/smart_collector.hpp
+++ b/include/smart_collector.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <functional>
 #include <chrono>
+#include <thread>
 #include <cstddef>
 
 class SmartFrameCollector {
@@ -13,7 +14,8 @@ public:
     using FrameReadyCallback = std::function<void(const std::vector<uint8_t>&)>;
 
     SmartFrameCollector(FrameReadyCallback callback, int k, int r);
-    void handle(const ChunkPacket& pkt);
+    ~SmartFrameCollector();
+    void handle(ChunkPacket pkt);
     void flush_expired_frames();
 
 private:
@@ -27,6 +29,10 @@ private:
 
     std::unordered_map<uint16_t, PartialFrame> frame_buffer;
     FrameReadyCallback callback;
+
+    std::thread flush_thread;
+    bool stop_flag = false;
+    int timeout_ms_ = 15;
 
     ErasureCoder fec;
     int k_; // data chunks

--- a/include/udp_sender.hpp
+++ b/include/udp_sender.hpp
@@ -4,12 +4,13 @@
 #include <vector>
 #include <string>
 
-// UDP soketlerini açar (bind gerekmez, client için)
-bool init_udp_sockets(size_t count);
+// UDP soketlerini açar ve belirtilen yerel portlara bind eder
+bool init_udp_sockets(const std::vector<int>& local_ports);
 
 // Soketleri kapatır
 void close_udp_sockets();
 
 // Bir ChunkPacket'i hedef IP ve port'a gönder
-void send_udp(const std::string& target_ip, int port, const ChunkPacket& packet);
+// Non-blocking send; dönen byte sayısı <0 ise hata
+ssize_t send_udp(const std::string& target_ip, int port, const ChunkPacket& packet);
 

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -43,6 +43,15 @@ PathStats WeightedScheduler::select_path() {
     return paths_.back(); // güvenlik için
 }
 
+void WeightedScheduler::update_metrics(const std::vector<PathStats>& paths) {
+    paths_ = paths;
+    for (auto& p : paths_) {
+        double score = 1000.0 / (p.rtt_ms + 1.0) * (1.0 - p.loss_ratio);
+        p.weight = std::max(1, static_cast<int>(score));
+    }
+    build_weight_table();
+}
+
 // ---------------------- Global interface ----------------------
 
 static WeightedScheduler* g_scheduler = nullptr;


### PR DESCRIPTION
## Summary
- enable dynamic bitrate adjustment using measured throughput
- implement real Reed–Solomon FEC via libjerasure
- start jitter-buffer flush thread and use std::move to minimise copies
- add non-blocking UDP sockets with EAGAIN retry
- enable multithreaded x264 encoding and expose setBitrate

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_688d26c1d690832cbad829d465061bbd